### PR TITLE
feat: Refactor flow control of consumer + producer

### DIFF
--- a/src/main/java/kafka/vertx/demo/PeriodicProducer.java
+++ b/src/main/java/kafka/vertx/demo/PeriodicProducer.java
@@ -48,12 +48,12 @@ public class PeriodicProducer extends AbstractVerticle {
   }
 
   private void handleCommand(TimeoutStream timerStream, Message<JsonObject> message) {
-    String command = message.body().getString("action", "none");
-    if ("start".equals(command)) {
+    String command = message.body().getString(WebSocketServer.ACTION, "none");
+    if (WebSocketServer.START_ACTION.equals(command)) {
       logger.info("Producing Kafka records");
       customMessage = message.body().getString("custom", "Hello World");
       timerStream.resume();
-    } else if ("stop".equals(command)) {
+    } else if (WebSocketServer.STOP_ACTION.equals(command)) {
       logger.info("Stopping producing Kafka records");
       timerStream.pause();
     }
@@ -62,6 +62,7 @@ public class PeriodicProducer extends AbstractVerticle {
   private void produceKafkaRecord(KafkaProducer<String, String> kafkaProducer, String topic) {
     String payload = customMessage;
     KafkaProducerRecord<String, String> record = KafkaProducerRecord.create(topic, payload);
+    logger.debug("Producing record to topic {} with payload {}", topic, payload);
 
     kafkaProducer
       .send(record)

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
   <logger name="io.vertx" level="info"/>
   <logger name="org.apache.kafka" level="error"/>
 
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="STDOUT"/>
   </root>
 


### PR DESCRIPTION
Refactor the flow of the consumer and producer.
Stop the producer when the websocket disconnects.
Only subscribe to the consumer when start is sent.

Signed-off-by: Katherine Stanley <katheris@uk.ibm.com>