### PR TITLE
hardcoded localhost doesn't allow containerization

### DIFF
--- a/src/main/java/kafka/vertx/demo/WebSocketServer.java
+++ b/src/main/java/kafka/vertx/demo/WebSocketServer.java
@@ -93,7 +93,7 @@ public class WebSocketServer extends AbstractVerticle {
     return vertx.createHttpServer()
       .requestHandler(router)
       .webSocketHandler(this::handleWebSocket)
-      .listen(8080, "localhost")
+      .listen(8080)
       .onSuccess(ok -> logger.info("🚀 WebSocketServer started"))
       .onFailure(err -> logger.error("❌ WebSocketServer failed to listen", err));
   }


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

## Commit Message
When the app is containerized, listening on localhost will not resolved when the app is hit from the host machine since incoming IP address would be <container-IP>:8080. Removing localhost will allow the server to handle requests from any IP address.

### Commit Message Title
fix: hardcoded localhost doesn't allow containerization

* The reviewer should ensure that the first commit message field is of this form when performing the `squash and merge` from this page.

### Commit Message Description
```
# When opening this PR, the raiser should replace this text with the remaining
# lines of their desired commit message, e.g:

Further details of the code going into the commit

Contributes to: #XYZ
Closes: #XYZ

Signed-off-by: Your Name <email@address.com>
```
* The reviewer should copy the above text into the extended description field when performing the `squash and merge` from this page.

## Checklist
- [ ] Automated tests exist
- [ ] Documentation exists [link]()
- [ ] Local unit tests performed
- [ ] Sufficient logging/trace
- [ ] Desired commit message set as PR title and commit description set above
