### PR TITLE
fix: release Github Action

### DIFF
--- a/.github/workflows/github-build-release.yml
+++ b/.github/workflows/github-build-release.yml
@@ -8,7 +8,6 @@ name: Build and create release
 jobs:
   build:
     name: Build and upload release binary
-    if: github.event.base_ref == 'refs/heads/master' # only run if on master branch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
The Action to create releases upon a tag being pushed to master has
stopped working as github.event.base_ref is always null
This commit removes the check that the tag has been pushed to the
master branch, must ensure in future that tags to trigger releases
are pushed to the correct location

Contributes to: mhub/qp-planning#7256

Signed-off-by: Dave <davilane@uk.ibm.com>

## Status
**READY/IN DEVELOPMENT/HOLD**

## Commit Message

### Commit Message Title
* When opening this PR, the raiser should set the title of this PR to the first line of their desired commit message, e.g:
```
feat|fix|docs|style|refactor|perf|test|chore: changed function X
```
* The reviewer should ensure that the first commit message field is of this form when performing the `squash and merge` from this page.

### Commit Message Description
```
# When opening this PR, the raiser should replace this text with the remaining
# lines of their desired commit message, e.g:

Further details of the code going into the commit

Contributes to: #XYZ
Closes: #XYZ

Signed-off-by: Your Name <email@address.com>
```
* The reviewer should copy the above text into the extended description field when performing the `squash and merge` from this page.

## Checklist
- [ ] Automated tests exist
- [ ] Documentation exists [link]()
- [ ] Local unit tests performed
- [ ] Sufficient logging/trace
- [ ] Desired commit message set as PR title and commit description set above
