### PR TITLE
feat: upgrade Java dependencies

### DIFF
--- a/.github/workflows/git-commit-lint.yml
+++ b/.github/workflows/git-commit-lint.yml
@@ -12,8 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+        #with:
+        #  ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
@@ -24,4 +24,5 @@ jobs:
         run: echo ${{ github.event.sender.login }}
       - name: Lint commit message
         if: ${{ github.event.sender.login != 'dependabot[bot]' }}
-        run: npx commitlint --from origin/${{ github.base_ref }} --to HEAD -g ./ui/package.json
+        #run: npx commitlint --from origin/${{ github.base_ref }} --to HEAD -g ./ui/package.json
+        run: npx commitlint --from origin/refs/heads/master --to HEAD -g ./ui/package.json

--- a/.github/workflows/git-commit-lint.yml
+++ b/.github/workflows/git-commit-lint.yml
@@ -1,6 +1,9 @@
 name: Git
 
-on: [pull_request]
+on: 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/git-commit-lint.yml
+++ b/.github/workflows/git-commit-lint.yml
@@ -22,3 +22,4 @@ jobs:
       - name: Lint commit message
         if: ${{ github.event.sender.login != 'dependabot[bot]' }}
         run: npx commitlint --from origin/${{ github.base_ref }} --to HEAD -g ./ui/package.json
+

--- a/.github/workflows/git-commit-lint.yml
+++ b/.github/workflows/git-commit-lint.yml
@@ -11,13 +11,13 @@ jobs:
     name: Lint Commit Messages
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: 20
       - name: Fetch origin
         run: git fetch origin
       - name: Event Sender

--- a/.github/workflows/git-commit-lint.yml
+++ b/.github/workflows/git-commit-lint.yml
@@ -1,19 +1,16 @@
 name: Git
 
-on: 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-  pull_request:
+on: [pull_request]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint Commit Messages
-
+    
     steps:
       - uses: actions/checkout@v4
-        #with:
-        #  ref: ${{ github.event.pull_request.head.sha }}
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
@@ -24,5 +21,4 @@ jobs:
         run: echo ${{ github.event.sender.login }}
       - name: Lint commit message
         if: ${{ github.event.sender.login != 'dependabot[bot]' }}
-        #run: npx commitlint --from origin/${{ github.base_ref }} --to HEAD -g ./ui/package.json
-        run: npx commitlint --from origin/refs/heads/master --to HEAD -g ./ui/package.json
+        run: npx commitlint --from origin/${{ github.base_ref }} --to HEAD -g ./ui/package.json

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
   <version>1.1.3</version>
 
   <properties>
-    <kafka.version>3.3.1</kafka.version>
     <vertx.version>4.3.6</vertx.version>
     <logback.version>1.2.6</logback.version>
     <jackson-databind.version>2.14.0</jackson-databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,21 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
   <groupId>kafka.vertx</groupId>
   <artifactId>demo</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4</version>
 
   <properties>
-    <vertx.version>4.3.6</vertx.version>
-    <logback.version>1.2.6</logback.version>
-    <jackson-databind.version>2.14.0</jackson-databind.version>
+    <vertx.version>4.5.10</vertx.version>
+    <logback.version>1.5.11</logback.version>
+    <jackson-databind.version>2.16.1</jackson-databind.version>
     <junit.version>5.9.2</junit.version>
     <hamcrest.version>2.2</hamcrest.version>
     <maven.surefire.version>3.0.0-M5</maven.surefire.version>
   </properties>
-
+  
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
Updates Java dependencies to latest available level.

jackson-databind is left at 2.16.1 instead of the very latest 2.18.1 because vertx-dependencies 4.5.10 pulls in 2.16.1. 
Note that 2.16.1 is not flagged as having security vulnerabilities at https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind so the upgrade to 2.18.1 is not critical at this point.

Signed-off-by: Trevor Dolby <trevor.dolby@ibm.com>

## Checklist
- [x] Automated tests exist
- [x] Documentation exists [link]()
- [x] Local unit tests performed
- [x] Sufficient logging/trace
- [x] Desired commit message set as PR title and commit description set above
