### PR TITLE
fix: Update color-string to 1.5.5

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7190,7 +7190,7 @@
       "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
       "requires": {
         "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
+        "color-string": "^1.5.5"
       }
     },
     "color-convert": {
@@ -7207,9 +7207,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"

--- a/ui/package.json
+++ b/ui/package.json
@@ -90,6 +90,9 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },
+  "overrides": {
+    "color-string": "1.5.5"
+  },
   "devDependencies": {
     "@babel/core": "^7.10.2",
     "@babel/preset-env": "^7.10.2",


### PR DESCRIPTION
This pull request updates the `color-string` dependency to version 1.5.5 to ensure the latest bug fixes and compatibility. The update is enforced using the `overrides` field in `package.json`, and the corresponding version is reflected in `package-lock.json`.

Dependency updates:

* Updated the `color-string` package from version 1.5.4 to 1.5.5 in `ui/package-lock.json` and set the new integrity hash. [[1]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L7193-R7193) [[2]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L7210-R7212)
* Added an `overrides` section to `ui/package.json` to enforce the use of `color-string` version 1.5.5.

## Checklist
- [ ] Automated tests exist
- [ ] Documentation exists [link]()
- [ ] Local unit tests performed
- [ ] Sufficient logging/trace
- [ ] Desired commit message set as PR title and commit description set above
