### PR TITLE
fix: upgrade lz4-java to 1.10.1 to address CVE-2025-12183 and CVE-2025-66566

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,17 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-kafka-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>at.yawk.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>1.10.1</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>


### PR DESCRIPTION
This pull request upgrades lz4-java dependency from 1.8.0 to 1.8.1 to fix security vulnerability.

Resolves: CVE-2025-12183 and CVE-2025-66566

Contributes to: [EVI-32161](https://jsw.ibm.com/browse/EVI-32161)

Signed-off-by: Meenu Mariya I <meenu.mariya@ibm.com>


