### PR TITLE
chore: bump logback version to 1.5.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <vertx.version>5.0.7</vertx.version>
-    <logback.version>1.5.11</logback.version>
+    <logback.version>1.5.28</logback.version>
     <jackson-databind.version>2.17.0</jackson-databind.version>
     <junit.version>5.10.2</junit.version>
     <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
This PR updates the logback from the vulnerable version 1.5.11 to the latest available version which is 1.5.28 to address the CVEs CVE-2024-12798 ,CVE-2025-11226
Closes: #382

Signed-off-by: Ladeeda Nasreen P <ladeedanasreen@ibm.com>