### PR TITLE
fix: Upgrade npm dependencies

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,7 +16,7 @@
         "carbon-components-react": "^7.43.0",
         "carbon-icons": "^7.0.7",
         "clsx": "^1.1.1",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.17.23",
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
       },
@@ -1916,11 +1916,12 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime-corejs3": {
@@ -7049,13 +7050,10 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "license": "MIT"
     },
     "node_modules/async-each": {
       "version": "1.0.3",
@@ -14220,16 +14218,17 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.1",
+        "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
         "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
@@ -20843,9 +20842,10 @@
       "dev": true
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -21423,15 +21423,16 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6"
       }
     },
     "node_modules/miller-rabin": {
@@ -23073,9 +23074,10 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -25029,7 +25031,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "dev": true
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
@@ -30020,11 +30023,6 @@
         "node": ">= 6.4.0"
       }
     },
-    "node_modules/winston/node_modules/async": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-    },
     "node_modules/winston/node_modules/is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -31687,12 +31685,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="
     },
     "@babel/runtime-corejs3": {
       "version": "7.10.2",
@@ -31825,7 +31820,7 @@
         "configstore": "^5.0.1",
         "fast-glob": "^3.2.4",
         "fs-extra": "^9.0.1",
-        "got": "^11.8.0",
+        "got": "11.8.5",
         "semver": "^7.3.2",
         "winston": "^3.3.3",
         "yargs": "^16.1.1"
@@ -31881,7 +31876,7 @@
             "@nodelib/fs.walk": "^1.2.3",
             "glob-parent": "^5.1.0",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
+            "micromatch": "^4.0.8",
             "picomatch": "^2.2.1"
           }
         },
@@ -32033,7 +32028,7 @@
       "integrity": "sha512-ctRrrPqjZ8r4Vc4FXpPaScEpkPwfvB0Us3NK2SD2AnLwXGMxOLFTabDmNySU1Xc40ud2CmJsaV8lpavvzs8ZZA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.6",
+        "@babel/runtime": "^7.26.10",
         "@commitlint/format": "^9.1.2",
         "@commitlint/lint": "^9.1.2",
         "@commitlint/load": "^9.1.2",
@@ -32431,7 +32426,7 @@
       "integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.26.10",
         "@emotion/cache": "^10.0.27",
         "@emotion/css": "^10.0.27",
         "@emotion/serialize": "^0.11.15",
@@ -32506,7 +32501,7 @@
       "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.26.10",
         "@emotion/is-prop-valid": "0.8.8",
         "@emotion/serialize": "^0.11.15",
         "@emotion/utils": "0.11.3"
@@ -32896,7 +32891,7 @@
         "jest-util": "^26.0.1",
         "jest-validate": "^26.0.1",
         "jest-watcher": "^26.0.1",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.8",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
@@ -33447,7 +33442,7 @@
         "jest-haste-map": "^26.0.1",
         "jest-regex-util": "^26.0.0",
         "jest-util": "^26.0.1",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.8",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
         "source-map": "^0.6.1",
@@ -34051,7 +34046,7 @@
         "ip": "^1.1.5",
         "json5": "^2.1.1",
         "lazy-universal-dotenv": "^3.0.1",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.8",
         "node-fetch": "^2.6.0",
         "open": "^7.0.0",
         "pnp-webpack-plugin": "1.5.0",
@@ -34682,7 +34677,7 @@
       "integrity": "sha512-4fT5l5L+5gfNhUZVCg0wnSszbRJ7A1ZHEz32v7OzH3mcY5lUsK++brI3IB2L9F5zO4kSDc2TRGEVa8v2hgl9vA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.26.10",
         "aria-query": "^4.0.2",
         "dom-accessibility-api": "^0.4.5",
         "pretty-format": "^25.5.0"
@@ -34694,7 +34689,7 @@
       "integrity": "sha512-uv9lLAnEFRzwUTN/y9lVVXVXlEzazDkelJtM5u92PsGkEasmdI+sfzhZHxSDzlhZVTrlLfuMh2safMr8YmzXLg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.2",
+        "@babel/runtime": "^7.26.10",
         "@types/testing-library__jest-dom": "^5.9.1",
         "chalk": "^3.0.0",
         "css": "^2.2.4",
@@ -34763,7 +34758,7 @@
       "integrity": "sha512-Rhn5uJK6lYHWzlGVbK6uAvheAW8AUoFYxTLGdDxgsJDaK/PYy5drWfW/6YpMMOKMw+u6jHHl4MNHlt5qLHnm0Q==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.26.10",
         "@testing-library/dom": "^7.14.2"
       }
     },
@@ -34773,7 +34768,7 @@
       "integrity": "sha512-rE9geI1+HJ6jqXkzzJ6abREbeud6bLF8OmF+Vyc7gBoPwZAEVBYjbC1up5nNoVfYBhO5HUwdD4u9mTehAUeiyw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.4",
+        "@babel/runtime": "^7.26.10",
         "@types/testing-library__react-hooks": "^3.0.0"
       }
     },
@@ -34783,7 +34778,7 @@
       "integrity": "sha512-pOclR3DWBnkwsI7rH4fXGzlqNbo8GiZ2gcRrFINweNfz31Xc8uyL1/NG6PIkPlo9wbM0a4Z8pF8v2haJEDNpvA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.2"
+        "@babel/runtime": "^7.26.10"
       }
     },
     "@types/anymatch": {
@@ -35647,7 +35642,7 @@
       "integrity": "sha512-tpVyXGt6gJVTVwCmu8qgBkDHhvtQ/es80y6J8ziybiwQU/x+LnCy+v8p9CWOTHv3i1BMnH5/IfzMpuTcFPCMQA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.26.10",
         "@babel/runtime-corejs3": "^7.10.2"
       }
     },
@@ -35844,13 +35839,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
     },
     "async-each": {
       "version": "1.0.3",
@@ -36235,7 +36226,7 @@
       "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.7.2",
+        "@babel/runtime": "^7.26.10",
         "cosmiconfig": "^6.0.0",
         "resolve": "^1.12.0"
       }
@@ -38849,7 +38840,7 @@
       "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.8.7",
+        "@babel/runtime": "^7.26.10",
         "csstype": "^2.6.7"
       }
     },
@@ -38985,7 +38976,7 @@
       "resolved": "https://registry.npmjs.org/downshift/-/downshift-5.2.1.tgz",
       "integrity": "sha512-uHX2OLbWthLR8QbR8NCI8OmjvvJxq8+PrA95KblFd9JyB1zVZh1HnszzsWMMCnMuH6IvsUtVfF5HY7XfijJ2dw==",
       "requires": {
-        "@babel/runtime": "^7.9.1",
+        "@babel/runtime": "^7.26.10",
         "compute-scroll-into-view": "^1.0.13",
         "prop-types": "^15.7.2",
         "react-is": "^16.13.1"
@@ -39087,7 +39078,7 @@
       "integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.26.10",
         "@emotion/weak-memoize": "0.2.5",
         "hoist-non-react-statics": "^3.3.0"
       }
@@ -39797,7 +39788,7 @@
       "integrity": "sha512-tHSWX2jXlAaiI45YuEPi3KXJ7MihvQWUZMR9UNB4bUVYvAamwr6AwCm5dgOZOV2rC2qVMjBtjNshBE46n4IG6w==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.26.10",
         "aria-query": "^4.2.0",
         "array-includes": "^3.1.1",
         "ast-types-flow": "^0.0.7",
@@ -40995,7 +40986,7 @@
       "integrity": "sha1-yVLeIkD4EuvaCqgAbXd27irPfXQ=",
       "dev": true,
       "requires": {
-        "async": ">=0.2.9",
+        "async": "3.2.2",
         "which": "^1.1.1"
       }
     },
@@ -41681,16 +41672,16 @@
       }
     },
     "got": {
-      "version": "11.8.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "requires": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.1",
+        "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
         "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
@@ -43723,7 +43714,7 @@
             "jest-haste-map": "^26.1.0",
             "jest-regex-util": "^26.0.0",
             "jest-util": "^26.1.0",
-            "micromatch": "^4.0.2",
+            "micromatch": "^4.0.8",
             "pirates": "^4.0.1",
             "slash": "^3.0.0",
             "source-map": "^0.6.1",
@@ -43869,7 +43860,7 @@
             "jest-resolve": "^26.1.0",
             "jest-util": "^26.1.0",
             "jest-validate": "^26.1.0",
-            "micromatch": "^4.0.2",
+            "micromatch": "^4.0.8",
             "pretty-format": "^26.1.0"
           }
         },
@@ -43946,7 +43937,7 @@
             "jest-serializer": "^26.1.0",
             "jest-util": "^26.1.0",
             "jest-worker": "^26.1.0",
-            "micromatch": "^4.0.2",
+            "micromatch": "^4.0.8",
             "sane": "^4.0.3",
             "walker": "^1.0.7",
             "which": "^2.0.2"
@@ -44010,7 +44001,7 @@
             "@types/stack-utils": "^1.0.1",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
-            "micromatch": "^4.0.2",
+            "micromatch": "^4.0.8",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.2"
           }
@@ -44143,7 +44134,7 @@
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "is-ci": "^2.0.0",
-            "micromatch": "^4.0.2"
+            "micromatch": "^4.0.8"
           }
         },
         "jest-validate": {
@@ -44236,7 +44227,7 @@
         "jest-resolve": "^26.0.1",
         "jest-util": "^26.0.1",
         "jest-validate": "^26.0.1",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.8",
         "pretty-format": "^26.0.1"
       },
       "dependencies": {
@@ -44666,7 +44657,7 @@
         "jest-serializer": "^26.0.0",
         "jest-util": "^26.0.1",
         "jest-worker": "^26.0.0",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.8",
         "sane": "^4.0.3",
         "walker": "^1.0.7",
         "which": "^2.0.2"
@@ -45059,7 +45050,7 @@
         "@types/stack-utils": "^1.0.1",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.8",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.2"
       },
@@ -46388,7 +46379,7 @@
       "integrity": "sha512-prXSYk799h3GY3iOWnC6ZigYzMPjxN2svgjJ9shk7oMadSNX3wXy0B6F32PMJv7qtMnrIbUxoEHzbutvxR2LBQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.0",
+        "@babel/runtime": "^7.26.10",
         "app-root-dir": "^1.0.2",
         "core-js": "^3.0.4",
         "dotenv": "^8.0.0",
@@ -46441,7 +46432,7 @@
         "execa": "^4.0.1",
         "listr2": "^2.1.0",
         "log-symbols": "^4.0.0",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "please-upgrade-node": "^3.2.0",
         "string-argv": "0.3.1",
@@ -46746,9 +46737,9 @@
       "dev": true
     },
     "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -47218,12 +47209,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "requires": {
         "braces": "^3.0.3",
-        "picomatch": "^2.0.5"
+        "picomatch": "^2.3.1"
       }
     },
     "miller-rabin": {
@@ -48538,9 +48529,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pidtree": {
       "version": "0.3.1",
@@ -48738,7 +48729,7 @@
       "integrity": "sha512-21moJXCm/7EvjeKQz5w89QDDKNPCoimc83CqwZZGJluFdMXsFlMQl9lPA/OMRkoceZ19kU0anKlMgZmY7LJSJw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.2"
+        "@babel/runtime": "^7.26.10"
       }
     },
     "popper.js": {
@@ -48753,7 +48744,7 @@
       "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
       "dev": true,
       "requires": {
-        "async": "^2.6.2",
+        "async": "3.2.2",
         "debug": "^3.1.1",
         "mkdirp": "^0.5.1"
       },
@@ -49349,7 +49340,7 @@
       "integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.0.0"
+        "@babel/runtime": "^7.26.10"
       }
     },
     "react-color": {
@@ -49634,7 +49625,7 @@
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.5",
-        "@babel/runtime": "^7.7.6",
+        "@babel/runtime": "^7.26.10",
         "ast-types": "^0.13.2",
         "commander": "^2.19.0",
         "doctrine": "^3.0.0",
@@ -49700,7 +49691,7 @@
       "integrity": "sha512-j15cWLPzH0gOmRrUg01C09Peu8qbcdVqr6Bjyfxj80cNZmH+idk/bNBYEDSmkAtwkXI+xEYWSmHYqtaQhZ8iUQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.0.0",
+        "@babel/runtime": "^7.26.10",
         "focus-lock": "^0.6.7",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.2",
@@ -49714,7 +49705,7 @@
       "integrity": "sha512-t+bhAI4NgxfEv8ez4r77cLfR4O4Z55E/FH2DT+uiE4U7yfWgAk7OAOi7IxHxuYEVLI26bqjZvlVCkpC5/5AoNA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.2",
+        "@babel/runtime": "^7.26.10",
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
         "react-fast-compare": "^3.0.1",
@@ -49745,7 +49736,7 @@
       "integrity": "sha512-xSiM6CE79JBqSj8Fzd9dWBHv57tLTH7OM57GP3VrE5crzVF3D5Khce9w1Xcw75OAbvrA0Mi2vBneR1OajKmXFg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.6.3",
+        "@babel/runtime": "^7.26.10",
         "is-dom": "^1.0.9",
         "prop-types": "^15.6.1"
       }
@@ -49767,7 +49758,7 @@
       "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2",
+        "@babel/runtime": "^7.26.10",
         "create-react-context": "^0.3.0",
         "deep-equal": "^1.1.1",
         "popper.js": "^1.14.4",
@@ -49793,7 +49784,7 @@
       "integrity": "sha512-04A2f24GhyyMicKvg/koIOQ5BzlrRbKiAgP6L+Pdj1MVX3yJ1NeZ8+EidndQsbejFT55oW1b++wg2Z8KlAyhfQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.2",
+        "@babel/runtime": "^7.26.10",
         "react-popper": "^1.3.7"
       }
     },
@@ -49803,7 +49794,7 @@
       "integrity": "sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.4",
+        "@babel/runtime": "^7.26.10",
         "@emotion/cache": "^10.0.9",
         "@emotion/core": "^10.0.9",
         "@emotion/css": "^10.0.9",
@@ -49831,7 +49822,7 @@
       "integrity": "sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.3.1",
+        "@babel/runtime": "^7.26.10",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
         "prismjs": "^1.8.4",
@@ -49856,7 +49847,7 @@
       "integrity": "sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2",
+        "@babel/runtime": "^7.26.10",
         "prop-types": "^15.6.0"
       }
     },
@@ -49866,7 +49857,7 @@
       "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.26.10",
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
@@ -50074,7 +50065,8 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -54046,7 +54038,7 @@
       "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
       "requires": {
         "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.1.0",
+        "async": "3.2.2",
         "is-stream": "^2.0.0",
         "logform": "^2.2.0",
         "one-time": "^1.0.0",
@@ -54056,11 +54048,6 @@
         "winston-transport": "^4.4.0"
       },
       "dependencies": {
-        "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-        },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -86,14 +86,18 @@
     "carbon-components-react": "^7.43.0",
     "carbon-icons": "^7.0.7",
     "clsx": "^1.1.1",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.17.23",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },
   "overrides": {
     "color-string": "1.5.5",
     "braces": "^3.0.3",
-    "ansi-regex": "5.0.1"
+    "ansi-regex": "5.0.1",
+    "async": "3.2.2",
+    "got": "11.8.5",
+    "micromatch@4.0.2": "^4.0.8",
+    "@babel/runtime": "^7.26.10"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",


### PR DESCRIPTION
This PR updates the following dependencies of npm using the overrides field in package.json:

Updates async to 3.2.2, which fixes the vulnerability CVE-2021-43138
Updates got to 11.8.5, which fixes the vulnerability CVE-2022-33987
Updates micromatch to 4.0.8, which fixes the vulnerability CVE-2024-4067
Updates @babel/runtime to 7.26.10, which fixes the vulnerability CVE-2025-27789
Updates lodash-es to 4.17.23 (direct dependency), which fixes the vulnerability CVE-2025-13465
Closes: #384

Signed-off-by: Ladeeda Nasreen P [ladeedanasreen@ibm.com](mailto:ladeedanasreen@ibm.com)