### PR TITLE
chore: upgrade Vert.x to 5.1.0 for Java 25 Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <version>1.1.4</version>
 
   <properties>
-    <vertx.version>5.0.7</vertx.version>
+    <vertx.version>5.1.0</vertx.version>
     <logback.version>1.5.28</logback.version>
     <jackson-databind.version>2.17.0</jackson-databind.version>
     <junit.version>5.10.2</junit.version>


### PR DESCRIPTION
Fixes #EVI-61576

## Status
**READY**

## Problem
Application fails on Java 25 with UnsupportedOperationException: getSubject is not supported during SASL authentication. Java 25 removed the deprecated Subject.getSubject() API that older Kafka clients relied on.

<img width="3456" height="1130" alt="image" src="https://github.com/user-attachments/assets/1e5d0335-43ac-4bff-a2dc-5ed4fe651ea6" />


- Upgraded Vert.x from 5.0.7 to 5.1.0, which includes Kafka clients 4.x with native Java 18+ support.


## Checklist
- [ ] Automated tests exist
- [ ] Documentation exists [link]()
- [ ] Local unit tests performed
- [ ] Sufficient logging/trace
- [ ] Desired commit message set as PR title and commit description set above
