### PR TITLE
chore: upgrade lodash-es from 4.17.23 to 4.18.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,7 +16,7 @@
         "carbon-components-react": "^7.43.0",
         "carbon-icons": "^7.0.7",
         "clsx": "^1.1.1",
-        "lodash-es": "^4.17.23",
+        "lodash-es": "^4.18.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
       },
@@ -20585,9 +20585,10 @@
       "dev": true
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.0.tgz",
+      "integrity": "sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA==",
+      "deprecated": "Bad release. Please use lodash-es@4.17.23 instead.",
       "license": "MIT"
     },
     "node_modules/lodash._reinterpolate": {
@@ -46275,9 +46276,9 @@
       "dev": true
     },
     "lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.0.tgz",
+      "integrity": "sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -86,7 +86,7 @@
     "carbon-components-react": "^7.43.0",
     "carbon-icons": "^7.0.7",
     "clsx": "^1.1.1",
-    "lodash-es": "^4.17.23",
+    "lodash-es": "^4.18.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },


### PR DESCRIPTION
This PR upgrades `lodash-es` dependency to `4.18.0`

Closes:  #390
Signed-off-by: Athira Sreekumar athira1693@gmail.com

