### PR TITLE
feat: pause Kafka consumer on subscription until start command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>kafka.vertx</groupId>
   <artifactId>demo</artifactId>
-  <version>1.1.5</version>
+  <version>1.1.6</version>
 
   <properties>
     <vertx.version>5.1.0</vertx.version>

--- a/src/main/java/kafka/vertx/demo/WebSocketServer.java
+++ b/src/main/java/kafka/vertx/demo/WebSocketServer.java
@@ -154,7 +154,6 @@ public class WebSocketServer extends AbstractVerticle {
         .onSuccess(v -> {
           logger.info("Subscribed to {}", topic);
           kafkaConsumer.pause();
-          logger.info("Consumer paused, waiting for start command");
         })
         .onFailure(err -> logger.error("Could not subscribe to {}", topic, err));
 

--- a/src/main/java/kafka/vertx/demo/WebSocketServer.java
+++ b/src/main/java/kafka/vertx/demo/WebSocketServer.java
@@ -153,6 +153,8 @@ public class WebSocketServer extends AbstractVerticle {
     kafkaConsumer.subscribe(topic)
         .onSuccess(v -> {
           logger.info("Subscribed to {}", topic);
+          kafkaConsumer.pause();
+          logger.info("Consumer paused, waiting for start command");
         })
         .onFailure(err -> logger.error("Could not subscribe to {}", topic, err));
 


### PR DESCRIPTION
The consumer was automatically starting to consume messages as soon as
the WebSocket connection was established, before the user clicked the
'Start Consuming' button. This fix pauses the consumer immediately
after subscription, ensuring consumption only begins when explicitly
started by the user.
