### PR TITLE
fix: upgrade picomatch to 2.3.2 to remediate CVE-2026-33671

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22796,9 +22796,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -31552,7 +31552,7 @@
             "glob-parent": "^5.1.0",
             "merge2": "^1.3.0",
             "micromatch": "^4.0.8",
-            "picomatch": "^2.2.1"
+            "picomatch": "2.3.2"
           }
         },
         "fs-extra": {
@@ -35209,7 +35209,7 @@
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
+        "picomatch": "2.3.2"
       }
     },
     "app-root-dir": {
@@ -46753,7 +46753,7 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "requires": {
         "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
+        "picomatch": "2.3.2"
       }
     },
     "miller-rabin": {
@@ -48055,9 +48055,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
     },
     "pidtree": {
       "version": "0.3.1",
@@ -49500,7 +49500,7 @@
       "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "dev": true,
       "requires": {
-        "picomatch": "^2.2.1"
+        "picomatch": "2.3.2"
       }
     },
     "recast": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -98,7 +98,8 @@
     "got": "11.8.5",
     "micromatch@4.0.2": "^4.0.8",
     "@babel/runtime": "^7.26.10",
-    "semver":"7.5.2"
+    "semver":"7.5.2",
+    "picomatch": "2.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",


### PR DESCRIPTION
Contributes to: #394

## Status
**READY**

## Commit Message

fix: upgrade picomatch to 2.3.2 to remediate CVE-2026-33671

Contributes to: #394

Signed-off-by: Meenu Mariya <Meenu.Mariya@ibm.com>
